### PR TITLE
fix: accept single-item list form of exo__Asset_prototype in all readers

### DIFF
--- a/packages/cli/src/commands/resolve-buttons.ts
+++ b/packages/cli/src/commands/resolve-buttons.ts
@@ -103,8 +103,16 @@ const UUID_RE =
  * first `|` display alias). Returns `null` for non-string / empty values.
  */
 function cleanRef(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  let cleaned = value.replace(/["'[\]]/g, "").trim();
+  // A frontmatter ref may be written as a scalar (`exo__Asset_prototype:
+  // "[[uid]]"`) OR as a single-item YAML list (`exo__Asset_prototype:\n  -
+  // "[[uid]]"`). Both forms are produced in practice — `exocortex-cli create`
+  // writes the scalar, hand-authored / list-migrated assets carry the list —
+  // so unwrap the first item before normalising. Without this the list form
+  // yields `null` and every prototype-scoped CommandBinding silently fails to
+  // match (@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec `I_direct` scenario).
+  const scalar = Array.isArray(value) ? value[0] : value;
+  if (typeof scalar !== "string") return null;
+  let cleaned = scalar.replace(/["'[\]]/g, "").trim();
   const pipe = cleaned.indexOf("|");
   if (pipe !== -1) cleaned = cleaned.slice(0, pipe).trim();
   return cleaned.length > 0 ? cleaned : null;

--- a/packages/cli/tests/integration/resolve-buttons.integration.test.ts
+++ b/packages/cli/tests/integration/resolve-buttons.integration.test.ts
@@ -60,6 +60,16 @@ const GND_UNBOUND = "3833eeee-0000-0000-0000-000000000003";
 const TARGET_CONCRETE = "3833ffff-0000-0000-0000-000000000001";
 const TARGET_PROTO = "3833ffff-0000-0000-0000-000000000002";
 
+// @req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec fixture — `exo__Asset_prototype`
+// occurs in TWO shapes in production vaults (19.5% of bearers carry the list
+// form) and a prototype-scoped binding must match under BOTH.
+const CMD_PROTOSCOPED = "5ad0bbbb-0000-0000-0000-000000000001";
+const BIND_PROTOSCOPED = "5ad0cccc-0000-0000-0000-000000000001";
+const GND_PROTOSCOPED = "5ad0eeee-0000-0000-0000-000000000001";
+const PROTO_ASSET = "5ad0ffff-0000-0000-0000-000000000001";
+const TARGET_LIST_PROTO = "5ad0ffff-0000-0000-0000-000000000002";
+const TARGET_SCALAR_PROTO = "5ad0ffff-0000-0000-0000-000000000003";
+
 const fm = (lines: string[]): string => ["---", ...lines, "---", ""].join("\n");
 
 // The shipped "not-a-prototype" leaf uses a STRENDS suffix check on the SYMBOLIC
@@ -116,6 +126,24 @@ function binding(
     `exo__Instance_class: ["[[exocmd__CommandBinding]]"]`,
     `exocmd__CommandBinding_command: "[[${commandUid}]]"`,
     `exocmd__CommandBinding_targetClass: ${targetClass}`,
+    `exocmd__CommandBinding_position: inline`,
+    `exocmd__CommandBinding_order: ${order}`,
+  ]);
+}
+
+/** Binding scoped by PROTOTYPE (not class) — @req:5ad0d6b4 shape. */
+function bindingToPrototype(
+  uid: string,
+  commandUid: string,
+  prototypeUid: string,
+  order: number,
+): string {
+  return fm([
+    `exo__Asset_uid: ${uid}`,
+    `exo__Asset_label: "binding ${uid}"`,
+    `exo__Instance_class: ["[[exocmd__CommandBinding]]"]`,
+    `exocmd__CommandBinding_command: "[[${commandUid}]]"`,
+    `exocmd__CommandBinding_targetPrototype: "[[${prototypeUid}]]"`,
     `exocmd__CommandBinding_position: inline`,
     `exocmd__CommandBinding_order: ${order}`,
   ]);
@@ -204,6 +232,54 @@ function buildVault(): string {
       `exo__Asset_uid: ${TARGET_PROTO}`,
       `exo__Asset_label: "Widget template"`,
       `exo__Instance_class: ["[[${CLASS_WIDGET_PROTO}]]"]`,
+    ]),
+  );
+
+  // --- @req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec: scalar vs list prototype ---
+  // A prototype-scoped command, its prototype asset, and TWO instances that
+  // differ ONLY in how `exo__Asset_prototype` is written. `exocortex-cli create`
+  // emits the scalar; hand-authored / list-migrated assets carry the single-item
+  // YAML list. Both must resolve the same button-set.
+  write(GND_PROTOSCOPED, grounding(GND_PROTOSCOPED, "ProtoScoped grounding"));
+  write(
+    CMD_PROTOSCOPED,
+    command(
+      CMD_PROTOSCOPED,
+      "ProtoScoped",
+      "proto-scoped",
+      GND_PROTOSCOPED,
+    ),
+  );
+  write(
+    BIND_PROTOSCOPED,
+    bindingToPrototype(BIND_PROTOSCOPED, CMD_PROTOSCOPED, PROTO_ASSET, 40),
+  );
+  write(
+    PROTO_ASSET,
+    fm([
+      `exo__Asset_uid: ${PROTO_ASSET}`,
+      `exo__Asset_label: "Widget prototype asset"`,
+      `exo__Instance_class: ["[[${CLASS_WIDGET}]]"]`,
+    ]),
+  );
+  write(
+    TARGET_SCALAR_PROTO,
+    fm([
+      `exo__Asset_uid: ${TARGET_SCALAR_PROTO}`,
+      `exo__Asset_label: "Instance (scalar prototype)"`,
+      `exo__Instance_class: ["[[${CLASS_WIDGET}]]"]`,
+      `exo__Asset_prototype: "[[${PROTO_ASSET}]]"`,
+    ]),
+  );
+  write(
+    TARGET_LIST_PROTO,
+    fm([
+      `exo__Asset_uid: ${TARGET_LIST_PROTO}`,
+      `exo__Asset_label: "Instance (list prototype)"`,
+      `exo__Instance_class: ["[[${CLASS_WIDGET}]]"]`,
+      // Single-item YAML list — the shape `cleanRef` used to reject.
+      `exo__Asset_prototype:`,
+      `  - "[[${PROTO_ASSET}]]"`,
     ]),
   );
 
@@ -456,6 +532,48 @@ describe("@req:960a7ba7-3470-42ba-afdc-f6766c3c3126 resolve-buttons — binding-
 // inline-button scope; the command palette is a separate path). `resolve-buttons`
 // is kept as a back-compat alias so existing scripts + the homoiconic-rule oracle
 // references (`resolve-buttons <target> --json`) keep resolving.
+/**
+ * @req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec — the `I_direct` scenario ("the
+ * bound command is present — direct-hop match") did not hold for assets whose
+ * `exo__Asset_prototype` is written as a single-item YAML list: `cleanRef`
+ * returned null for a non-string, so `prototypeIRI` was undefined and EVERY
+ * prototype-scoped binding silently failed to match.
+ *
+ * REVERT-VERIFY anchor: drop the `Array.isArray(value) ? value[0] : value`
+ * unwrap in `cleanRef` (packages/cli/src/commands/resolve-buttons.ts) → the
+ * list-form axis goes RED (`visible` loses "ProtoScoped"), while the scalar
+ * axis stays GREEN — proving the axis discriminates the SHAPE, not the binding.
+ */
+describe("@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec prototype ref: scalar AND single-item list resolve identically", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = buildVault();
+  });
+
+  afterEach(() => {
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec SCALAR prototype → prototype-scoped command visible (pre-existing behavior, control)", async () => {
+    const result = await resolveButtons(root, `${TARGET_SCALAR_PROTO}.md`);
+    expect(result.visible.map((e) => e.label)).toContain("ProtoScoped");
+  });
+
+  it("@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec LIST prototype → SAME command visible (the shape that used to yield null)", async () => {
+    const result = await resolveButtons(root, `${TARGET_LIST_PROTO}.md`);
+    expect(result.visible.map((e) => e.label)).toContain("ProtoScoped");
+  });
+
+  it("@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec both shapes yield the same button-set (shape is not observable downstream)", async () => {
+    const scalar = await resolveButtons(root, `${TARGET_SCALAR_PROTO}.md`);
+    const list = await resolveButtons(root, `${TARGET_LIST_PROTO}.md`);
+    expect(list.visible.map((e) => e.label).sort()).toEqual(
+      scalar.visible.map((e) => e.label).sort(),
+    );
+  });
+});
+
 describe("issue #4077 — every CLI resolver construction site passes a logger", () => {
   // ⛔ The behavioural axis above covers resolve-buttons only. `apply` constructs its
   // own resolver and would regress silently: its diagnostics have no stdout contract to

--- a/packages/obsidian-plugin/src/application/api/ExocortexAPI.ts
+++ b/packages/obsidian-plugin/src/application/api/ExocortexAPI.ts
@@ -540,7 +540,11 @@ export class ExocortexAPI {
   }
 
   private extractPrototype(frontmatter: Record<string, unknown>): string | null {
-    const prototype = frontmatter.exo__Asset_prototype;
+    // Scalar OR single-item YAML list — both shapes exist in production vaults
+    // (the sibling status extractor above already unwraps arrays; this one did
+    // not, so list-form assets reported "no prototype").
+    const raw = frontmatter.exo__Asset_prototype;
+    const prototype = Array.isArray(raw) ? raw[0] : raw;
     if (!prototype || typeof prototype !== 'string') {
       return null;
     }

--- a/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
+++ b/packages/obsidian-plugin/src/presentation/builders/button-groups/DynamicCommandButtonGroupBuilder.ts
@@ -659,9 +659,16 @@ export class DynamicCommandButtonGroupBuilder implements IButtonGroupBuilder {
   private extractPrototypeIRI(
     metadata: Record<string, unknown>,
   ): string | undefined {
+    // Accept BOTH frontmatter shapes: scalar (`exo__Asset_prototype: "[[uid]]"`)
+    // and single-item YAML list (`exo__Asset_prototype:\n  - "[[uid]]"`). Both
+    // occur in production vaults; treating the list as "no prototype" made every
+    // prototype-scoped CommandBinding silently unmatched for those assets
+    // (@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec — the resolver walks the chain,
+    // but only ever received the START of it from here).
     const raw = metadata["exo__Asset_prototype"];
-    if (typeof raw === "string") {
-      return raw.replace(/["'[\]]/g, "").trim();
+    const scalar = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof scalar === "string") {
+      return scalar.replace(/["'[\]]/g, "").trim();
     }
     return undefined;
   }

--- a/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
+++ b/packages/obsidian-plugin/src/presentation/renderers/DailyTasksRenderer.ts
@@ -326,7 +326,11 @@ export class DailyTasksRenderer {
     metadata: Record<string, unknown>,
     allFiles: IFile[],
   ): unknown {
-    const prototypeRef = metadata.exo__Asset_prototype;
+    // Scalar OR single-item YAML list — both shapes exist in production vaults.
+    const rawPrototype = metadata.exo__Asset_prototype;
+    const prototypeRef = Array.isArray(rawPrototype)
+      ? rawPrototype[0]
+      : rawPrototype;
     if (!prototypeRef || typeof prototypeRef !== 'string') {
       return null;
     }

--- a/packages/obsidian-plugin/src/types/index.ts
+++ b/packages/obsidian-plugin/src/types/index.ts
@@ -22,7 +22,11 @@ export interface AssetMetadata {
 
   ems__Effort_status?: string | string[];
   ems__Effort_votes?: number;
-  exo__Asset_prototype?: string;
+  // Scalar (`exo__Asset_prototype: "[[uid]]"`, written by `exocortex-cli
+  // create`) OR single-item YAML list (hand-authored / list-migrated assets).
+  // Both shapes occur in production vaults — readers MUST unwrap the array
+  // before normalising (@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec).
+  exo__Asset_prototype?: string | string[];
   ems__Effort_startTimestamp?: string | number;
   ems__Effort_plannedStartTimestamp?: string | number;
   ems__Effort_endTimestamp?: string | number;

--- a/packages/obsidian-plugin/tests/unit/api/ExocortexAPI.test.ts
+++ b/packages/obsidian-plugin/tests/unit/api/ExocortexAPI.test.ts
@@ -205,6 +205,29 @@ describe("ExocortexAPI", () => {
 
       expect(metadata!.prototype).toBe("my-prototype");
     });
+
+    // `exo__Asset_prototype` occurs BOTH as a scalar (written by
+    // `exocortex-cli create`) and as a single-item YAML list (hand-authored /
+    // list-migrated assets — 19.5% of bearers in the live personal vault).
+    // Before the unwrap, the list form failed the `typeof !== 'string'` guard
+    // and this API reported "no prototype" for a fifth of real assets.
+    //
+    // REVERT-VERIFY anchor: drop the `Array.isArray(raw) ? raw[0] : raw`
+    // unwrap in `extractPrototype` → this axis goes RED (prototype becomes
+    // null), while the scalar axis above stays GREEN.
+    it("should read the prototype when it is a single-item LIST (same as the scalar form)", () => {
+      const mockFile = createMockTFile("test.md");
+      mockVault.getAbstractFileByPath.mockReturnValue(mockFile);
+      mockMetadataCache.getFileCache.mockReturnValue({
+        frontmatter: {
+          exo__Asset_prototype: ["[[my-prototype]]"],
+        },
+      });
+
+      const metadata = api.getAssetMetadata("test.md");
+
+      expect(metadata!.prototype).toBe("my-prototype");
+    });
   });
 
   describe("getAssetRelations", () => {

--- a/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
+++ b/packages/obsidian-plugin/tests/unit/presentation/builders/DynamicCommandButtonGroupBuilder.test.ts
@@ -293,6 +293,48 @@ describe("DynamicCommandButtonGroupBuilder", () => {
       );
     });
 
+    // @req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec — `exo__Asset_prototype` is
+    // written BOTH as a scalar (`exocortex-cli create`) and as a single-item
+    // YAML list (hand-authored / list-migrated; 19.5% of bearers in vault-my).
+    // `extractPrototypeIRI` used to treat the list as "no prototype", so the
+    // resolver never received the START of the chain it walks — every
+    // prototype-scoped binding silently failed to match for those assets.
+    //
+    // REVERT-VERIFY anchor: drop the `Array.isArray(raw) ? raw[0] : raw` unwrap
+    // in `extractPrototypeIRI` → this axis goes RED (third argument becomes
+    // `undefined`), while the scalar axis above stays GREEN.
+    it("@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec should pass the prototype when it is a single-item LIST (same as the scalar form)", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const context = createContext({
+        exo__Asset_uid: "obsidian://vault/test/file.md",
+        exo__Instance_class: ["[[ems__Task]]"],
+        exo__Asset_prototype: ["proto-uid"],
+      });
+      await builder.build(context);
+
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        ["ems__Task", "exo__Asset"],
+        "proto-uid",
+      );
+    });
+
+    it("@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec should strip wikilink brackets from a LIST-form prototype ref", async () => {
+      mockResolveForAssetMulti.mockResolvedValue([]);
+      const context = createContext({
+        exo__Asset_uid: "obsidian://vault/test/file.md",
+        exo__Instance_class: ["[[ems__Task]]"],
+        exo__Asset_prototype: ['"[[proto-uid]]"'],
+      });
+      await builder.build(context);
+
+      expect(mockResolveForAssetMulti).toHaveBeenCalledWith(
+        "obsidian://vault/test/file.md",
+        ["ems__Task", "exo__Asset"],
+        "proto-uid",
+      );
+    });
+
     it("should handle array instance class — pass all classes plus universal exo__Asset (Issue #2958)", async () => {
       mockResolveForAssetMulti.mockResolvedValue([]);
       const context = createContext({

--- a/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.edgeCases.test.ts
+++ b/packages/obsidian-plugin/tests/unit/renderers/dailyTasks/DailyTasksRenderer.edgeCases.test.ts
@@ -264,4 +264,78 @@ describe("DailyTasksRenderer - edge cases and error handling", () => {
     // _prototypeClasses should be resolved from prototype's exo__Instance_class
     expect(tasks[0].metadata._prototypeClasses).toEqual(["[[ems__Task]]", "[[ems__Context]]"]);
   });
+
+  // Same as the test above, but the prototype ref is written as a single-item
+  // YAML list instead of a scalar. Both shapes occur in production vaults —
+  // `exocortex-cli create` emits the scalar, hand-authored / list-migrated
+  // assets carry the list (19.5% of bearers in the live personal vault).
+  // Before the unwrap, `resolvePrototypeClasses` failed the
+  // `typeof !== 'string'` guard and returned null, so overlap detection
+  // silently lost the prototype's classes for those tasks.
+  //
+  // REVERT-VERIFY anchor: drop the `Array.isArray(rawPrototype) ? ... : ...`
+  // unwrap in `resolvePrototypeClasses` → this axis goes RED
+  // (_prototypeClasses undefined), while the scalar axis above stays GREEN.
+  it("should resolve prototype classes when exo__Asset_prototype is a single-item LIST", async () => {
+    const mockFile = {
+      path: "test.md",
+      parent: { path: "DailyNotes" },
+      basename: "2025-10-20",
+    } as TFile;
+    const dailyNoteMetadata = {
+      exo__Instance_class: ["[[pn__DailyNote]]"],
+      pn__DailyNote_day: "[[2025-10-20]]",
+    };
+
+    const taskFile = { path: "task.md", basename: "task" } as TFile;
+    const prototypeFile = {
+      path: "fb3d12b2-9552-4866-a31e-2b5f65ea433c.md",
+      basename: "fb3d12b2-9552-4866-a31e-2b5f65ea433c",
+    } as TFile;
+
+    const taskMetadata = {
+      exo__Instance_class: ["[[ems__Task]]"],
+      ems__Effort_day: "[[2025-10-20]]",
+      ems__Effort_startTimestamp: "2025-10-20T09:00:00",
+      ems__Effort_status: "[[ems__EffortStatusDoing]]",
+      // Single-item YAML list — the shape that used to yield null.
+      exo__Asset_prototype: ["[[fb3d12b2-9552-4866-a31e-2b5f65ea433c]]"],
+    };
+
+    const prototypeMetadata = {
+      exo__Instance_class: ["[[ems__Task]]", "[[ems__Context]]"],
+    };
+
+    ctx.mockMetadataExtractor.extractMetadata.mockImplementation((file: any) => {
+      if (file.path === "test.md") return dailyNoteMetadata;
+      if (file.path === "task.md") return taskMetadata;
+      if (file.path === "fb3d12b2-9552-4866-a31e-2b5f65ea433c.md")
+        return prototypeMetadata;
+      return {};
+    });
+
+    ctx.mockMetadataExtractor.extractInstanceClass.mockReturnValue(
+      "[[pn__DailyNote]]",
+    );
+
+    ctx.mockVaultAdapter.getAllFiles.mockReturnValue([taskFile, prototypeFile]);
+
+    const mockEl = createMockElement();
+    await ctx.renderer.render(mockEl, mockFile);
+
+    expect(ctx.mockReactRenderer.render).toHaveBeenCalled();
+    // `mock.calls[0][1]` is `unknown` under the tests tsconfig; the sibling
+    // tests above carry that as baselined TS2571 debt — a new test must not
+    // add another instance (scripts/check-test-types.mjs ratchet).
+    const renderCall = ctx.mockReactRenderer.render.mock.calls[0] as unknown as [
+      unknown,
+      { props: { tasks: Array<{ metadata: Record<string, unknown> }> } },
+    ];
+    const tasks = renderCall[1].props.tasks;
+
+    expect(tasks[0].metadata._prototypeClasses).toEqual([
+      "[[ems__Task]]",
+      "[[ems__Context]]",
+    ]);
+  });
 });


### PR DESCRIPTION
## Дефект

`exo__Asset_prototype` встречается в живых vault'ах в **двух** формах:

```yaml
exo__Asset_prototype: "[[uid]]"     # скаляр — так пишет `exocortex-cli create`
exo__Asset_prototype:               # односоставный YAML-список — рукописные
  - "[[uid]]"                       # / мигрированные ассеты
```

Замер радиуса на vault-my: **46 из 236 носителей (19.5 %)** несут список.

Каждый читатель стоял на `typeof x === "string"` и трактовал список как «прототипа нет»
⇒ для пятой части реальных ассетов цепочка прототипа **не начиналась вовсе**.
Один дефект, четыре читателя:

| # | файл | функция |
|---|---|---|
| 1 | `packages/cli/src/commands/resolve-buttons.ts` | `cleanRef` |
| 2 | `packages/obsidian-plugin/…/DynamicCommandButtonGroupBuilder.ts` | `extractPrototypeIRI` |
| 3 | `packages/obsidian-plugin/…/api/ExocortexAPI.ts` | `extractPrototype` |
| 4 | `packages/obsidian-plugin/…/renderers/DailyTasksRenderer.ts` | `resolvePrototypeClasses` |

Тип расширен до `string | string[]` в `AssetMetadata` — как у уже расширенных соседей
`exo__Instance_class` и `ems__Effort_status`.

## Маршрут (`/feature-sdd` Step 0)

Читатель 1 — **conformance-gap активного** req `5ad0d6b4-2c9a-4375-bb5b-04e754861bec`
(prototype-scoped command routing): его сценарий I_direct («команда привязана, прямой хоп,
существующее поведение сохранено») **не выполняется** на list-form ассетах. Per Step 0
§conformance-with-an-active-req это bug-fix, **расширяющий `@req`-покрытие существующего
требования**; нового req нет.

Читатели 2-4 — тот же дефект на поверхностях **вне** спеки этого req, поэтому у них свои
оси и они **не** помечены `@req:5ad0d6b4`.

## Revert-verify

Каждый unwrap снят отдельно; каждая ось краснеет **только своя**:

| читатель | чисто | мутант |
|---|---|---|
| 1 — CLI integration (реальный temp-vault, реальная команда `resolveButtons`) | 12 passed | **2 failed / 10 passed** — LIST + both-shapes-equal; SCALAR-контроль **зелёный** |
| 2 — `DynamicCommandButtonGroupBuilder` | 73 passed | **2 failed / 71 passed**, обе `- "proto-uid"` / `+ undefined`; scalar зелёный |
| 3 — `ExocortexAPI` | — | **1 failed** — ровно своя LIST-ось |
| 4 — `DailyTasksRenderer` | — | **1 failed** — ровно своя LIST-ось |

Зелёный SCALAR-контроль под мутантом — доказательство, что оси различают **форму записи**,
а не наличие биндинга.

## Гейты

`check:types` rc=0 · `check-cli-types` rc=0 (13/13 пар базы) ·
`check-test-types` rc=0 (431/431 базы) · CLI 12/12 · плагин 108/108.

## Вне scope — названо явно

- **Ратчет** против будущего голого `typeof raw === "string"` на этом поле **намеренно
  отложен**: он охраняет класс, этот PR закрывает экземпляры.
- **Внешнего код-ревью не было**: суб-агенты недоступны этой сессии по директиве, то есть
  гейт **структурно отсутствует**, а не пропущен. Замена — revert-verify выше.

@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec

https://claude.ai/code/session_01C4U1HuiUrFu7gy47K71PLs
