### PR TITLE
fix(core): emit the SYMBOLIC class IRI under a cold metadataCache (Tier 3, @req:7d00a60b)

### DIFF
--- a/packages/core/src/services/NoteToRDFConverter.ts
+++ b/packages/core/src/services/NoteToRDFConverter.ts
@@ -214,6 +214,24 @@ export class NoteToRDFConverter {
    */
   private readonly emitInstanceClassAsUid: boolean;
 
+  /**
+   * Tier 3 of RFC 8f93ff95 (req 7d00a60b): class-file frontmatter read FROM DISK
+   * ahead of the synchronous resolver.
+   *
+   * `valueToClassURI` is synchronous, and the corpus recipe for that shape is
+   * pre-resolution rather than an async cascade (making it async would ripple
+   * through every caller). So the class files a note references are resolved here,
+   * in the async entry point, and parked in this map for the sync resolver to read.
+   *
+   * Keyed by file path. Consulted ONLY after `getFrontmatter` returns null, i.e.
+   * only while the cache is cold — once Obsidian has re-indexed, the cache wins and
+   * this map is never read, so a stale entry cannot surface.
+   */
+  private readonly preResolvedClassFm = new Map<
+    string,
+    Record<string, unknown> | null
+  >();
+
   constructor(
     @inject(DI_TOKENS.IVaultAdapter) private readonly vault: IVaultAdapter,
     @inject(DI_TOKENS.ILogger) private readonly logger: ILogger = NullLogger,
@@ -282,6 +300,11 @@ export class NoteToRDFConverter {
     if (!frontmatter) {
       return [];
     }
+
+    // Tier 3 (req 7d00a60b): warm the class-frontmatter map from disk BEFORE the
+    // synchronous class resolution below. No-op when the cache is warm or when the
+    // adapter has no disk fallback (CLI / in-memory doubles).
+    await this.preResolveClassFrontmatter(frontmatter);
 
     // RFC 1ce2a226 Phase 3a: emit exo:Asset_filename for every parsed file.
     // `file.basename` is the disk basename without `.md` extension, already
@@ -1637,6 +1660,54 @@ export class NoteToRDFConverter {
    * valueToClassURI("[[SomeNote]]")   // → Literal("[[SomeNote]]") (not a class reference)
    * ```
    */
+  /**
+   * Tier 3 of RFC 8f93ff95 (req 7d00a60b) — pre-resolve class-file frontmatter.
+   *
+   * Reuses {@link valueToClassURI}'s OWN normalisation (`removeQuotes` ->
+   * `extractWikilink`) rather than re-parsing the value, so the two cannot drift.
+   *
+   * Scope is deliberately `exo__Instance_class` only: per req 7d00a60b's non-goals,
+   * that is the reference which gates `rdf:type` and therefore the buttons; widening
+   * to other wikilink positions needs its own measurement.
+   *
+   * Cost: one adapter read per DISTINCT cold class file (classes number in the tens,
+   * assets in the thousands), and zero once the cache is warm — the `getFrontmatter`
+   * probe below short-circuits before any read.
+   */
+  private async preResolveClassFrontmatter(
+    frontmatter: Record<string, unknown>,
+  ): Promise<void> {
+    const withFallback = this.vault.getFrontmatterWithFallback;
+    if (!withFallback) {
+      return; // CLI adapter / in-memory doubles: nothing to fall back to
+    }
+
+    const raw = frontmatter["exo__Instance_class"];
+    const values = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
+
+    for (const value of values) {
+      if (typeof value !== "string") {
+        continue;
+      }
+      const cleanValue = this.removeQuotes(value);
+      const classRef = this.extractWikilink(cleanValue) || cleanValue;
+      if (!this.isUUID(classRef)) {
+        continue; // label-form / uid+alias resolve without any lookup
+      }
+      const resolvedFile = this.vault.getFirstLinkpathDest(classRef, "");
+      if (!resolvedFile || this.preResolvedClassFm.has(resolvedFile.path)) {
+        continue;
+      }
+      if (this.vault.getFrontmatter(resolvedFile)) {
+        continue; // cache is warm for this class — the resolver will use it
+      }
+      this.preResolvedClassFm.set(
+        resolvedFile.path,
+        await withFallback.call(this.vault, resolvedFile),
+      );
+    }
+  }
+
   private valueToClassURI(value: unknown): IRI | Literal {
     if (typeof value !== "string") {
       return new Literal(String(value));
@@ -1689,7 +1760,14 @@ export class NoteToRDFConverter {
             : basenameIRI;
         }
 
-        const fm = this.vault.getFrontmatter(resolvedFile);
+        // Tier 3 (req 7d00a60b): cold cache => getFrontmatter is null => the label
+        // is never seen => the code used to fall through to notePathToIRI() and emit
+        // a FILE-IRI, silently breaking every ASK precondition that compares against
+        // the SYMBOLIC form (3 of 36 on vault-my, incl. "Is Prototype").
+        const fm =
+          this.vault.getFrontmatter(resolvedFile) ??
+          this.preResolvedClassFm.get(resolvedFile.path) ??
+          null;
         if (fm) {
           const label = fm["exo__Asset_label"];
           if (typeof label === "string") {

--- a/packages/core/tests/unit/services/NoteToRDFConverter.cold-cache-class-iri-form.test.ts
+++ b/packages/core/tests/unit/services/NoteToRDFConverter.cold-cache-class-iri-form.test.ts
@@ -1,0 +1,134 @@
+import "reflect-metadata";
+import { NoteToRDFConverter } from "../../../src/services/NoteToRDFConverter";
+import { IVaultAdapter, IFile } from "../../../src/interfaces/IVaultAdapter";
+import type { ILogger } from "../../../src/interfaces/ILogger";
+import { Namespace } from "../../../src/domain/models/rdf/Namespace";
+
+function createMockLogger(): jest.Mocked<ILogger> {
+  return { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+}
+
+const CLASS_UID = "11111111-2222-4333-8444-555555555555";
+
+/** UID-CANON: a class file's NAME is its uuid, so the basename carries no
+ *  namespace — the symbolic IRI can only come from its exo__Asset_label. */
+const CLASS_FILE: IFile = {
+  path: "assetspaces/kitelev/exoas-exo/exo/" + CLASS_UID + ".md",
+  basename: CLASS_UID,
+  name: CLASS_UID + ".md",
+} as IFile;
+
+const ASSET_FILE: IFile = {
+  path: "assetspaces/kitelev/exoas-my/my-efforts/96e2a59a.md",
+  basename: "96e2a59a",
+  name: "96e2a59a.md",
+} as IFile;
+
+const ASSET_FM = {
+  exo__Asset_uid: "96e2a59a-6ac1-47fb-83ab-12a9964a5bea",
+  exo__Instance_class: "[[" + CLASS_UID + "]]", // uid-bare form
+};
+
+const CLASS_FM = { exo__Asset_label: "exo__Prototype" };
+
+/** The Obsidian-shaped adapter: it HAS the disk fallback (req c3072a80). */
+function createVault(): jest.Mocked<IVaultAdapter> & {
+  getFrontmatterWithFallback: jest.Mock;
+} {
+  const v = {
+    getFrontmatter: jest.fn(),
+    getAllFiles: jest.fn(),
+    read: jest.fn(),
+    create: jest.fn(),
+    modify: jest.fn(),
+    delete: jest.fn(),
+    exists: jest.fn(),
+    getAbstractFileByPath: jest.fn(),
+    updateFrontmatter: jest.fn(),
+    rename: jest.fn(),
+    createFolder: jest.fn(),
+    getFirstLinkpathDest: jest.fn(),
+    process: jest.fn(),
+    updateLinks: jest.fn(),
+    getDefaultNewFileParent: jest.fn(),
+    getFrontmatterWithFallback: jest.fn(),
+  } as unknown as jest.Mocked<IVaultAdapter> & {
+    getFrontmatterWithFallback: jest.Mock;
+  };
+  return v;
+}
+
+/**
+ * @req:7d00a60b-5ca3-457e-a160-5bf955e8c195
+ *
+ * Tier 3 — the FORM of the class IRI under a cold cache.
+ *
+ * Tier 1 (own frontmatter) and Tier 2 (linkpath -> file) are closed: on a cold
+ * cache the store is no longer empty and the class reference no longer collapses
+ * to a Literal. What is NOT closed is the FORM the class IRI takes.
+ *
+ * req 7d00a60b.covers promises: "the SYMBOLIC type-IRI is emitted". Under a cold
+ * cache valueToClassURI resolves the class FILE (Tier 2, from disk) but then reads
+ * its label through the CACHE only (`this.vault.getFrontmatter(resolvedFile)`) —
+ * no disk fallback. Cold => null => the label is never seen => the code falls
+ * through to notePathToIRI() and emits a FILE-IRI instead.
+ *
+ * A file-IRI is graph-traversable, so buttons gated on a *path* still work — but
+ * every ASK precondition that compares against the symbolic form silently stops
+ * matching. Measured on vault-my (2026-08-29): 3 of 36 preconditions compare
+ * symbolically, one of them being "Is Prototype", which gates the prototype
+ * buttons — matching the observed "some buttons missing, not all".
+ */
+describe("NoteToRDFConverter — cold cache, class IRI FORM (Tier 3, req 7d00a60b)", () => {
+  it("emits the SYMBOLIC class IRI when only the cache is cold", async () => {
+    const vault = createVault();
+    const converter = new NoteToRDFConverter(vault, createMockLogger());
+
+    // cold cache: nothing is in metadataCache
+    vault.getFrontmatter.mockReturnValue(null);
+    // Tier 1 + Tier 2 already work: the asset's own fm and the class FILE resolve
+    vault.getFrontmatterWithFallback.mockImplementation(async (f: IFile) =>
+      f.path === ASSET_FILE.path ? ASSET_FM : CLASS_FM,
+    );
+    (vault.getFirstLinkpathDest as jest.Mock).mockReturnValue(CLASS_FILE);
+
+    const triples = await converter.convertNote(ASSET_FILE);
+
+    const typePred = Namespace.EXO.term("Instance_class").toString();
+    const classObjects = triples
+      .filter((t) => t.predicate.toString() === typePred)
+      .map((t) => t.object.toString());
+
+    expect(classObjects.length).toBeGreaterThan(0);
+    expect(classObjects[0]).toBe(
+      Namespace.EXO.term("Prototype").toString(),
+    );
+  });
+
+  /** req 7d00a60b scenario 2: "the already-working forms are not disturbed —
+   *  the class IRI is produced WITHOUT any disk or cache lookup". The Tier-3
+   *  pre-resolution must not add a lookup for the label-bare form. */
+  it("does NOT touch disk for the label-bare form", async () => {
+    const vault = createVault();
+    const converter = new NoteToRDFConverter(vault, createMockLogger());
+
+    vault.getFrontmatter.mockReturnValue(null);
+    vault.getFrontmatterWithFallback.mockResolvedValue({
+      exo__Asset_uid: "96e2a59a-6ac1-47fb-83ab-12a9964a5bea",
+      exo__Instance_class: "[[exo__Prototype]]", // label-bare: no lookup needed
+    });
+    (vault.getFirstLinkpathDest as jest.Mock).mockReturnValue(CLASS_FILE);
+
+    const triples = await converter.convertNote(ASSET_FILE);
+
+    const typePred = Namespace.EXO.term("Instance_class").toString();
+    const objects = triples
+      .filter((t) => t.predicate.toString() === typePred)
+      .map((t) => t.object.toString());
+
+    expect(objects[0]).toBe(Namespace.EXO.term("Prototype").toString());
+    // exactly ONE fallback read: the asset's own frontmatter (Tier 1). The class
+    // reference resolved from its own text, so no second read was issued.
+    expect(vault.getFrontmatterWithFallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/cold-cache-symbolic-class-iri.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/cold-cache-symbolic-class-iri.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  launchObsidianWithPlugin,
+  log,
+  setupGuiVault,
+  waitForStoreSettled,
+} from "./eka-gui-helpers";
+
+/**
+ * ============================================================================
+ *  EKA GUI BDD — the class IRI keeps its SYMBOLIC form on a cold metadataCache
+ * ============================================================================
+ *
+ * @req:7d00a60b-5ca3-457e-a160-5bf955e8c195
+ *
+ * Tier 3 of RFC 8f93ff95. Tiers 1-2 are closed, so on a cold cache the store is
+ * no longer empty and the class reference no longer collapses to a Literal. What
+ * this guards is the FORM: `valueToClassURI` used to read the resolved class
+ * file's label through the CACHE only, so cold => null => fall-through to a
+ * FILE-IRI. That IRI is graph-traversable, hence buttons gated on a path still
+ * render — but every ASK precondition comparing against the SYMBOLIC form
+ * silently stops matching (3 of 36 on vault-my, incl. "Is Prototype").
+ *
+ * The unit axes pin the converter in isolation. This one exists because they
+ * cannot: only here do the REAL ObsidianVaultAdapter, the REAL metadataCache and
+ * the REAL disk read take part — i.e. exactly the boundary that was cold on the
+ * phone.
+ *
+ * The cold state is CONSTRUCTED, never awaited: `getFileCache` is stubbed to
+ * return null for the class file only, and the test fails LOUD if that stub did
+ * not take effect — a green assertion against a still-warm cache would be
+ * vacuous, and silently so.
+ */
+
+const SEED_DIR_REL = "assetspaces/kitelev/exoas-public/ems";
+const CLASS_UID = "0e2e0001-c1a5-4c1a-9c1a-000000000001";
+const ASSET_UID = "0e2e0002-a55e-4a55-8a55-000000000002";
+/** Namespace-parseable label: the ONLY source of the symbolic IRI, since the
+ *  file's basename is its uuid under the UID-CANON invariant. */
+const CLASS_LABEL = "ems__E2eColdClass";
+const EXPECTED_IRI = "https://exocortex.my/ontology/ems#E2eColdClass";
+
+const CLASS_REL = path.posix.join(SEED_DIR_REL, `${CLASS_UID}.md`);
+const ASSET_REL = path.posix.join(SEED_DIR_REL, `${ASSET_UID}.md`);
+
+function writeSeeds(vaultPath: string): void {
+  const dir = path.join(vaultPath, SEED_DIR_REL);
+  fs.mkdirSync(dir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(dir, `${CLASS_UID}.md`),
+    `---\n` +
+      `exo__Asset_uid: ${CLASS_UID}\n` +
+      `exo__Asset_label: ${CLASS_LABEL}\n` +
+      `---\n\nEphemeral e2e class for the cold-cache IRI-form scenario.\n`,
+  );
+
+  // uid-bare class reference — the canonical UID-CANON form, and the only one
+  // that needs a lookup at all (label-bare / uid+alias resolve from their text).
+  fs.writeFileSync(
+    path.join(dir, `${ASSET_UID}.md`),
+    `---\n` +
+      `exo__Asset_uid: ${ASSET_UID}\n` +
+      `exo__Instance_class:\n  - "[[${CLASS_UID}]]"\n` +
+      `exo__Asset_label: EKA E2E Cold Class-IRI Asset\n` +
+      `---\n\nEphemeral e2e asset whose class ref must survive a cold cache.\n`,
+  );
+}
+
+/** Read back the object of the asset's exo__Instance_class triple. */
+async function classObjectInStore(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  window: any,
+  assetRel: string,
+): Promise<string[]> {
+  return window.evaluate(async (rel: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const plugin = (window as any).app?.plugins?.plugins?.exocortex;
+    const store = plugin?.sparql?.getTripleStore?.();
+    const loader = plugin?.lazyAssetGraphLoader;
+    if (!store || !loader) return ["<no store/loader>"];
+    const subject = loader.notePathToIRI(rel);
+    const triples = await store.match(subject, undefined, undefined);
+    return triples
+      .filter((t: { predicate: { toString(): string } }) =>
+        t.predicate.toString().endsWith("#Instance_class"),
+      )
+      .map((t: { object: { toString(): string } }) => t.object.toString());
+  }, assetRel);
+}
+
+test.describe("EKA GUI BDD — symbolic class IRI under a cold metadataCache", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let vaultPath: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let launcher: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let window: any;
+
+  test.beforeAll(async () => {
+    vaultPath = setupGuiVault();
+    writeSeeds(vaultPath);
+    log(`cold-class-iri: vault ${vaultPath}`);
+    launcher = await launchObsidianWithPlugin(vaultPath, "cold-class-iri");
+    window = await launcher.getWindow();
+    await waitForStoreSettled(window);
+  });
+
+  test.afterAll(async () => {
+    await launcher?.close().catch(() => undefined);
+  });
+
+  test(`@req:7d00a60b-5ca3-457e-a160-5bf955e8c195 warm control — the class IRI is symbolic to begin with`, async () => {
+    const objects = await classObjectInStore(window, ASSET_REL);
+    log(`cold-class-iri: warm objects = ${JSON.stringify(objects)}`);
+    expect(
+      objects,
+      "the seed asset produced no Instance_class triple at all — the scenario is vacuous",
+    ).toContain(EXPECTED_IRI);
+  });
+
+  test(`@req:7d00a60b-5ca3-457e-a160-5bf955e8c195 cold cache — the class IRI stays SYMBOLIC, not a file IRI`, async () => {
+    const cold = await window.evaluate(
+      async ([classRel, assetRel]: [string, string]) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const w = window as any;
+        const app = w.app;
+        const plugin = app?.plugins?.plugins?.exocortex;
+        const loader = plugin?.lazyAssetGraphLoader;
+        const store = plugin?.sparql?.getTripleStore?.();
+        if (!loader || !store)
+          return { ok: false, reason: "loader/store unavailable" };
+
+        const classFile = app.vault.getAbstractFileByPath(classRel);
+        const assetFile = app.vault.getAbstractFileByPath(assetRel);
+        if (!classFile || !assetFile)
+          return { ok: false, reason: "seed files not found" };
+
+        // ── construct the cold state: the CLASS file only, deterministically ──
+        const original = app.metadataCache.getFileCache.bind(app.metadataCache);
+        app.metadataCache.getFileCache = (f: { path: string }) =>
+          f?.path === classRel ? null : original(f);
+        const stubWorks = app.metadataCache.getFileCache(classFile) === null;
+        const othersWarm = !!app.metadataCache.getFileCache(assetFile);
+
+        // Re-derive the asset's triples through the REAL lazy-load path.
+        const assetIRI = loader.notePathToIRI(assetRel);
+        const owned = await store.match(assetIRI, undefined, undefined);
+        const removed = await store.removeAll(owned);
+        loader.forget(assetIRI);
+        await loader.ensureFileLoaded(assetFile);
+
+        const after = await store.match(assetIRI, undefined, undefined);
+        const objects = after
+          .filter((t: { predicate: { toString(): string } }) =>
+            t.predicate.toString().endsWith("#Instance_class"),
+          )
+          .map((t: { object: { toString(): string } }) => t.object.toString());
+
+        app.metadataCache.getFileCache = original; // restore
+        return { ok: true, stubWorks, othersWarm, removed, objects };
+      },
+      [CLASS_REL, ASSET_REL],
+    );
+
+    log(`cold-class-iri: cold state = ${JSON.stringify(cold)}`);
+    expect(cold.ok, `cold setup failed: ${cold.reason}`).toBe(true);
+    // Fail LOUD on a vacuous run: if the stub never took effect, or the asset had
+    // no triples to re-derive, a green assertion would prove nothing.
+    expect(
+      cold.stubWorks,
+      "getFileCache stub did not take effect — the cache is NOT cold",
+    ).toBe(true);
+    expect(
+      cold.othersWarm,
+      "the stub went too wide — it must starve the CLASS file only",
+    ).toBe(true);
+    expect(
+      cold.removed,
+      "asset had no triples to re-derive — the scenario is vacuous",
+    ).toBeGreaterThan(0);
+
+    expect(cold.objects).toContain(EXPECTED_IRI);
+    expect(
+      cold.objects.some((o: string) => o.startsWith("obsidian://vault/")),
+      "a FILE-IRI was emitted — Tier 3 has regressed",
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Что и почему

Третий и последний ярус холодного `metadataCache` (RFC 8f93ff95). Ярусы 1-2 закрыты:

| ярус | что ломалось на холодном кэше | статус |
|---|---|---|
| 1 | собственный frontmatter ассета → **пустой store** | ✅ v16.235.1 (`getFrontmatterWithFallback`) |
| 2 | `getFirstLinkpathDest` → null → `Literal` → нет `rdf:type` → **ноль кнопок** | ✅ PR #4199 |
| **3** | `getFrontmatter(классФайл)` → null → эмитится **file-IRI вместо symbolic** → **часть кнопок** | ⛔ этот PR |

**Это bug-fix, не новый req.** `7d00a60b.covers` дословно обещает *«the **symbolic** type-IRI is emitted»*; §Non-goals выносит другие позиции wikilink, скорость реиндекса и label-legacy — форму IRI **не** выносит. По Step 0 `/feature-sdd` это конформность с активным требованием ⇒ расширяю `@req:7d00a60b`.

## Механизм

`valueToClassURI` резолвит класс-**файл** с диска (ярус 2 работает), а затем читает его `exo__Asset_label` **только через кэш** — без disk-fallback. Холодно ⇒ `null` ⇒ метка не увидена ⇒ fall-through в `notePathToIRI()`.

File-IRI остаётся graph-traversable, поэтому кнопки, загейченные по пути, рендерятся — а **каждый ASK-precondition, сравнивающий с symbolic-формой, молча перестаёт матчить**. Замер vault-my (2026-08-29): symbolic сравнивают **3 из 36** preconditions, одна из них — `Is Prototype`, гейтящая прототипные кнопки. Это ровно наблюдавшееся «часть кнопок пропала, не все».

## Фикс

`valueToClassURI` синхронный, поэтому рецепт — **pre-resolution**, а не async-каскад (тот прошёл бы по всем вызывающим). `convertNoteFromFrontmatter` — общая точка входа конвертера, `VaultRDFIndexer` и CLI-валидатора — прогревает карту `path → frontmatter` с диска до синхронного резолва.

Карта читается **только после** того, как `getFrontmatter` вернул `null`, то есть исключительно на холодном кэше: прогретый кэш всегда побеждает, поэтому устаревшая запись проявиться не может. Область — `exo__Instance_class`, по §Non-goals требования.

Стоимость: одно чтение адаптера на **уникальный холодный класс** (классов десятки, ассетов тысячи), ноль на прогретом кэше. Мобильный паритет соблюдён — чтение идёт через тот же `vault.adapter`, никаких Node-only зависимостей.

## Верификация

**RED→GREEN замерен, не выведен.** До фикса: ожидалось `https://exocortex.my/ontology/exo#Prototype`, получено `obsidian://vault/.../<uuid>.md`.

**Две оси, каждая заперта своим мутантом — различимость предъявлена поимённо:**

| мутант | краснеет |
|---|---|
| убрать чтение из карты | **только** «emits the SYMBOLIC class IRI» |
| убрать guard `isUUID` | **только** «does NOT touch disk for the label-bare form» |
| контроль | обе зелёные |

Вторая ось — прямо сценарий 2 требования («уже работающие формы не потревожены, без дисковых чтений»): проверяет, что pre-resolution не добавил чтения для label-bare формы (ровно один fallback-read — собственный frontmatter яруса 1).

**Регрессия:** core 388/388 сьютов, 8711 passed, **0 failed**; obsidian-plugin 354/354, 6170 passed, **0 failed**; `check:types` rc=0; все пять гвардов `lint`-джобы rc=0 (`check-cli-types` 116 файлов / 13 пар = базовая линия; `check-test-types` 1012 файлов / 431 пара = базовая линия — то есть прогоны не вакуумны).

⚠ Первые 9 красных оказались **неинициализированным submodule** в worktree (`ENOENT` на `packages/exoas-exocmd/exocmd`) — идентично с фиксом и без него; после `submodule update --init` интеграционные сьюты 15/15, 108/108. Гипотеза «сломал утренними правками данных в exoas-exocmd» проверена и **опровергнута**.

