### PR TITLE
docs(reqs): полные UUID в 15 усечённых @req-тегах (заявлено было 4)

### DIFF
--- a/packages/cli/tests/integration/resolve-buttons.integration.test.ts
+++ b/packages/cli/tests/integration/resolve-buttons.integration.test.ts
@@ -131,7 +131,7 @@ function binding(
   ]);
 }
 
-/** Binding scoped by PROTOTYPE (not class) — @req:5ad0d6b4 shape. */
+/** Binding scoped by PROTOTYPE (not class) — @req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec shape. */
 function bindingToPrototype(
   uid: string,
   commandUid: string,

--- a/packages/core/src/services/CommandResolver.ts
+++ b/packages/core/src/services/CommandResolver.ts
@@ -326,7 +326,7 @@ export class CommandResolver {
    *                      resolve identically.
    * @param prototypeIRI - Optional DIRECT prototype ref of the target
    *   (`exo__Asset_prototype`); expanded resolver-side into the transitive
-   *   prototype chain for `targetPrototype` matching (@req:5ad0d6b4)
+   *   prototype chain for `targetPrototype` matching (@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec)
    * @returns Resolved commands sorted by `(priority, depth, order)`; deduped by
    *          binding.id; overridden bindings removed
    */
@@ -348,7 +348,7 @@ export class CommandResolver {
     if (cached) return cached;
 
     // 0. Expand the direct prototype ref into its transitive prototype chain
-    //    ONCE for the whole per-class loop (@req:5ad0d6b4).
+    //    ONCE for the whole per-class loop (@req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec).
     const prototypeChain = prototypeIRI
       ? await this.expandPrototypeChain(prototypeIRI)
       : undefined;
@@ -1280,7 +1280,7 @@ export class CommandResolver {
     }
 
     // targetPrototype: match ANY ancestor in the target's prototype chain
-    // (chain[0] = the direct prototype — @req:5ad0d6b4).
+    // (chain[0] = the direct prototype — @req:5ad0d6b4-2c9a-4375-bb5b-04e754861bec).
     if (binding.targetPrototype && prototypeChain) {
       for (const prototypeRef of prototypeChain) {
         if (this.matchesReference(binding.targetPrototype, prototypeRef))
@@ -2976,7 +2976,7 @@ export class CommandResolver {
     // the SubstitutionToken check — which cannot catch it either, because an
     // invocation carries no `_resolver` — and the ref is emitted as
     // `"[[<uid>]]"` where the substituted value belonged. The first door was
-    // closed by `@req:ef825945…`; without this one the corruption survives.
+    // closed by `@req:ef825945-62a8-4a9d-b5ea-5992903d3bff…`; without this one the corruption survives.
     //
     // The tie cannot be broken by the class triple: its absence IS the failure.
     // `exocmd__TokenInvocation_token` breaks it — on the pinned
@@ -3007,7 +3007,7 @@ export class CommandResolver {
     // enforce it. Checking `_token` first would therefore fire that line on an
     // invocation whose class is right there — a lie.
     // VERIFIED BY PERMUTATION, not argued: moving this block above the class
-    // loop reddens exactly one axis, `@req:81d2e07e… stays silent for a
+    // loop reddens exactly one axis, `@req:81d2e07e-413e-4e40-9159-83ccdb813561… stays silent for a
     // well-formed invocation` (1 failed / 20 passed).
     const tokenTriples = await this.tripleStore.match(
       subject,
@@ -3087,7 +3087,7 @@ export class CommandResolver {
     // carries the resolver property (16/16 on the pinned corpus), so running the
     // resolver check first would fire that line on EVERY correctly-classified
     // token — making it a lie. VERIFIED BY PERMUTATION, not argued: moving this
-    // block above the class loop reddens exactly one axis, `@req:b354316b… stays
+    // block above the class loop reddens exactly one axis, `@req:b354316b-3b26-478b-a8c0-18606da8e6ec… stays
     // silent on the happy path` (1 failed / 16 passed).
     //
     // The class triple is precisely what is missing in the failure this guards:

--- a/packages/core/tests/unit/services/GroundingExecutor.workflow_transition.test.ts
+++ b/packages/core/tests/unit/services/GroundingExecutor.workflow_transition.test.ts
@@ -295,7 +295,7 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
   // dispatch is a graceful no-op (notApplicable), and when the class DOES have a
   // workflow (per-asset override / per-class ABox) the transition works.
 
-  it("@req:7489624f graceful no-op (notApplicable) when class has no applicable workflow — no crash", async () => {
+  it("@req:7489624f-c17f-47dd-8108-3571a5809f61 graceful no-op (notApplicable) when class has no applicable workflow — no crash", async () => {
     // resolveForAssetOrNull returns null → the class (e.g. ems__Action, ems__Idea,
     // exo__Asset) has no status workflow. Must NOT surface the old fail-loud
     // "no recognised ems__* class" error.
@@ -321,7 +321,7 @@ describe("GroundingExecutor.workflow_transition (RFC 36347daf Phase 2)", () => {
     expect(workflowResolver.resolveForAssetOrNull).toHaveBeenCalledTimes(1);
   });
 
-  it("@req:7489624f data-driven transition works for a NON-built-in class with a workflow", async () => {
+  it("@req:7489624f-c17f-47dd-8108-3571a5809f61 data-driven transition works for a NON-built-in class with a workflow", async () => {
     // A class outside Task/Project/Meeting (UID-canon form) whose asset has a
     // declared workflow (e.g. via ems__Effort_workflow) resolves and transitions
     // Doing→Backlog — proving the dispatch is no longer gated by a hardcoded

--- a/packages/obsidian-plugin/tests/e2e/eka-gui/cold-cache-symbolic-class-iri.spec.ts
+++ b/packages/obsidian-plugin/tests/e2e/eka-gui/cold-cache-symbolic-class-iri.spec.ts
@@ -43,7 +43,7 @@ const CLASS_LABEL = "ems__E2eColdClass";
 const EXPECTED_IRI = "https://exocortex.my/ontology/ems#E2eColdClass";
 
 const STATUS_UID = "0e2e0003-57a7-4575-8575-000000000003";
-/** Tier 4 (@req:f3ec4a75): an enum VALUE resolves through the SAME
+/** Tier 4 (@req:f3ec4a75-f49c-47db-9cd6-5c8d09fbf0e0): an enum VALUE resolves through the SAME
  *  label->symbolic lookup as the class position. */
 const STATUS_LABEL = "ems__E2eColdStatus";
 const STATUS_IRI = "https://exocortex.my/ontology/ems#E2eColdStatus";

--- a/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-coverage-monotonic.test.ts
@@ -22,7 +22,7 @@ import { spawnSync } from "child_process";
  *
  * @req:289f87f4-23c8-4106-8069-0823c45167fe
  */
-describe("check-coverage-monotonic.mjs — coverage-threshold monotonicity (P5.1, @req:289f87f4)", () => {
+describe("check-coverage-monotonic.mjs — coverage-threshold monotonicity (P5.1, @req:289f87f4-23c8-4106-8069-0823c45167fe)", () => {
   const repoRoot = path.resolve(__dirname, "../../../../..");
   const scriptPath = path.join(repoRoot, "scripts/check-coverage-monotonic.mjs");
 

--- a/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
+++ b/packages/obsidian-plugin/tests/unit/build/check-test-antipatterns-overmock.test.ts
@@ -28,7 +28,7 @@ import { spawnSync } from "child_process";
  *
  * @req:427530e2-6365-48ae-9bfc-513180333ecd
  */
-describe("check-test-antipatterns.sh — over-mock pass-through ratchet (P2, @req:427530e2)", () => {
+describe("check-test-antipatterns.sh — over-mock pass-through ratchet (P2, @req:427530e2-6365-48ae-9bfc-513180333ecd)", () => {
   const repoRoot = path.resolve(__dirname, "../../../../..");
   const scriptPath = path.join(repoRoot, "scripts/check-test-antipatterns.sh");
 

--- a/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
+++ b/packages/obsidian-plugin/tests/unit/presentation/components/DynamicForm.test.tsx
@@ -82,12 +82,12 @@ describe("DynamicForm", () => {
       jest.useRealTimers();
     });
 
-    it("@req:57b03ab3 resolves a date field's '$today' defaultValue to today's date", () => {
+    it("@req:57b03ab3-9666-4c5a-8f38-cf650e4f48d2 resolves a date field's '$today' defaultValue to today's date", () => {
       renderForm([{ name: "plannedDate", type: "date", defaultValue: "$today" }]);
       expect(screen.getByTestId("field-plannedDate")).toHaveValue("2026-06-28");
     });
 
-    it("@req:57b03ab3 submits the resolved today date as the field value", () => {
+    it("@req:57b03ab3-9666-4c5a-8f38-cf650e4f48d2 submits the resolved today date as the field value", () => {
       const { onSubmit } = renderForm([
         { name: "label", type: "text", defaultValue: "x" },
         { name: "plannedDate", type: "date", defaultValue: "$today" },
@@ -99,7 +99,7 @@ describe("DynamicForm", () => {
       });
     });
 
-    it("@req:57b03ab3 leaves a literal date and non-'$today' text defaultValue untouched", () => {
+    it("@req:57b03ab3-9666-4c5a-8f38-cf650e4f48d2 leaves a literal date and non-'$today' text defaultValue untouched", () => {
       renderForm([
         { name: "plannedDate", type: "date", defaultValue: "2026-01-15" },
         { name: "note", type: "text", defaultValue: "$todayish" },


### PR DESCRIPTION
## Что и почему

Усечённый `@req:<8 hex>` **тегом не является**: `REQ_TAG_RE` аудита матчит только полный UUID,
поэтому короткая форма — orphan. Archgate REQ-001 флагует её лишь **warning'ом** (не блокирует),
а active-gate `requirements-trace` — **hard-block всему репо**, как только такой тег окажется
у требования единственным.

## Замер (origin/main, 2026-08-30)

⚠ `git grep -P '@req:[0-9a-f]{8}(?![0-9a-f-])'` дал **ложный ноль** при живой канарейке в 807
тегов — считал python по выдаче `git grep '@req:'`.

**Усечённых тегов: 15 · требований: 9 · все девять Active** (постановка задачи называла 4).

| требование | полных | усечённых |
|---|---|---|
| `5ad0d6b4` | 25 | 4 |
| `b354316b` | 5 | 1 |
| `f3ec4a75` | 5 | 1 |
| `81d2e07e` | 4 | 1 |
| `ef825945` | 2 | 1 |
| `7489624f` | 2 | 2 |
| `289f87f4` | **1** | 1 |
| `427530e2` | **1** | 1 |
| `57b03ab3` | **1** | 3 |

Orphan'ов **сейчас нет** — у каждого требования есть хотя бы один полный тег, поэтому мина не
сработала. ⚠ Но три требования висят на **единственном** полном теге: рефакторинг одного теста
делает их orphan и роняет весь репо. После правки их запас `1 → 2`, `1 → 2`, `1 → 4`.

## Как проверено

- **Флип:** усечённых до правки **15**, после — **0**.
- **Дифф трогает только строки с тегами:** строк без `@req:` в диффе — **0** (15 вставок / 15 удалений).
- **UUID не дописаны по памяти:** подставлены программно из имён файлов в клонах
  `exoas-exo-reqs` / `exoas-ems-reqs`; каждый из девяти проверен на существование файла — **9/9**.

## Scope

Comment-only, поведение не меняется ⇒ по `/feature-sdd` Step 0 exempt (docs), нового требования
не нужно. Статусы требований не трогались.

Задача: `66e2b947-d382-41d6-98d8-d7926bb7cbc9` (vault-exodev).

https://claude.ai/code/session_01Lwzrz2xQvSCaKLFSxQxRLZ
