### PR TITLE
fix(sync): an empty remote tree is an empty file list, not an unreachable repo

### DIFF
--- a/packages/core/src/services/sync/githubRepoReader.ts
+++ b/packages/core/src/services/sync/githubRepoReader.ts
@@ -88,11 +88,27 @@ export async function getCommitInfo(
 }
 
 /**
+ * The canonical git empty tree.
+ *
+ * A branch head may legitimately reference it — the repo exists and the branch
+ * resolves, there is simply nothing committed yet. GitHub nevertheless answers
+ * **404** for `GET git/trees/<this sha>` even when the repo is reachable and
+ * the PAT allowlists it: the 404 is a property of the REQUEST, not of
+ * reachability. Callers that classify 404 as "repo unreachable" would report a
+ * healthy empty repo as an error (req 029c90ee).
+ */
+export const EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/**
  * GET git/trees/{treeSha}?recursive=1 → blob entries (path + sha).
  *
  * Fails LOUD on `truncated: true` (GitHub truncates past ~100k entries /
  * 7 MB) — a truncated tree would produce wrong diffs and phantom deletes, so
  * the caller must skip the repo with a warning instead.
+ *
+ * Short-circuits {@link EMPTY_TREE_SHA}: an empty tree contains zero blobs by
+ * definition, so the answer is known without a round trip — and without
+ * inheriting GitHub's 404 for that SHA.
  */
 export async function getTree(
   transport: RestCommitTransport,
@@ -101,6 +117,7 @@ export async function getTree(
   treeSha: string,
   baseURL?: string,
 ): Promise<RemoteTreeEntry[]> {
+  if (treeSha === EMPTY_TREE_SHA) return [];
   const resp = await transport({
     method: "GET",
     url: `${api(baseURL)}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/trees/${encodeURIComponent(treeSha)}?recursive=1`,

--- a/packages/core/tests/unit/services/sync/ParityValidator.test.ts
+++ b/packages/core/tests/unit/services/sync/ParityValidator.test.ts
@@ -18,6 +18,8 @@ import {
   type SyncRepoSpec,
   type YamlCodec,
 } from "../../../../src";
+import { EMPTY_TREE_SHA } from "../../../../src/services/sync/githubRepoReader";
+import type { RestCommitTransport } from "../../../../src/infrastructure/github/restCommit";
 import {
   FakeGitHubRepo,
   FakeLocalFiles,
@@ -736,5 +738,73 @@ describe("ParityValidator — file-mode repos (attachment sub-check)", () => {
       { path: "img/logo.png", cls: "pending-conflict" },
     ]);
     expect(diverged.repos[0].discrepancies[0].detail).toMatch(/binary/);
+  });
+});
+
+/**
+ * Issue #4184 — a repo whose branch head references the canonical git empty
+ * tree is healthy but unpopulated. GitHub answers 404 for that tree SHA, so
+ * parity used to report `error` and name two false causes (dead pointer, PAT
+ * allowlist). Worse, discrepancy counting is gated on `status === "checked"`,
+ * so local files stayed invisible — parity went quiet exactly when it should
+ * have proposed a first push.
+ */
+describe("ParityValidator — empty remote tree (@req:029c90ee-e10b-4398-909e-c2784fed7ac9)", () => {
+  /**
+   * Rewrites only the commit lookup so the head references the canonical empty
+   * tree. The 404 that follows is produced by the fake's real tree route (it
+   * holds no such tree) — exactly what GitHub returns for that SHA.
+   */
+  function withEmptyRemoteTree(
+    inner: RestCommitTransport,
+  ): RestCommitTransport {
+    return async (req) => {
+      const resp = await inner(req);
+      if (/\/git\/commits\//.test(req.url)) {
+        const json = (resp.json ?? {}) as Record<string, unknown>;
+        return { ...resp, json: { ...json, tree: { sha: EMPTY_TREE_SHA } } };
+      }
+      return resp;
+    };
+  }
+
+  function validatorOver(h: Harness): ParityValidator {
+    return new ParityValidator({
+      transport: withEmptyRemoteTree(h.gh.transport()),
+      sha1: sha1Hex,
+      localFilesFor: () => h.local,
+      watermarks: h.watermarks,
+      yaml: codec,
+      now: () => "2026-06-11T00:00:00.000Z",
+    });
+  }
+
+  it("B1: reports checked (not error) and counts the local asset as a pending add", async () => {
+    const h = makeHarness({});
+    await bootstrap(h);
+    h.local.files.set(FILE_A, mdAsset("u1"));
+
+    const round = await validatorOver(h).runRound([h.spec], {
+      trigger: "standalone",
+    });
+
+    expect(round.repos[0].status).toBe("checked");
+    expect(round.repos[0].warnings.join(" ")).not.toMatch(/fine-grained PAT/);
+    expect(round.repos[0].discrepancies).toMatchObject([
+      { path: FILE_A, cls: "pending-local-add" },
+    ]);
+  });
+
+  it("B2: an empty repo with no local files is clean, not an error", async () => {
+    const h = makeHarness({});
+    await bootstrap(h);
+
+    const round = await validatorOver(h).runRound([h.spec], {
+      trigger: "standalone",
+    });
+
+    expect(round.repos[0].status).toBe("checked");
+    expect(round.repos[0].discrepancies).toEqual([]);
+    expect(round.ok).toBe(true);
   });
 });

--- a/packages/core/tests/unit/services/sync/githubRepoReader.empty-tree.test.ts
+++ b/packages/core/tests/unit/services/sync/githubRepoReader.empty-tree.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #4184 — an empty remote tree is an empty file list, not an error.
+ *
+ * A branch head may legitimately reference the canonical git empty tree
+ * (`4b825dc6…`): the repo exists, the branch resolves, nothing is committed
+ * yet. GitHub still answers **404** for `GET git/trees/4b825dc6…` even when
+ * the repo is reachable and allowlisted — the 404 is a property of the
+ * REQUEST, not of reachability. Every `getTree` caller that classifies 404 as
+ * "repo unreachable" therefore misreports a healthy empty repo.
+ *
+ * Empirically revert-verified per
+ * ~/dotfiles/.claude/rules/integration-test-revert-verify.md: removing the
+ * short-circuit makes A1 RED (the stub throws the same 404 GitHub does) while
+ * A2 stays GREEN, so A2 is the control proving A1 is not vacuous.
+ */
+import {
+  EMPTY_TREE_SHA,
+  getTree,
+} from "../../../../src/services/sync/githubRepoReader";
+import type {
+  RestCommitRequest,
+  RestCommitTransport,
+} from "../../../../src/infrastructure/github/restCommit";
+
+/**
+ * Transport mirroring GitHub for tree reads: a known SHA yields blob entries,
+ * anything else — including the empty tree — throws the 404 the real API
+ * returns. Records every request so "no round trip" is observable.
+ */
+function treeTransport(known: Record<string, string>): {
+  transport: RestCommitTransport;
+  requests: RestCommitRequest[];
+} {
+  const requests: RestCommitRequest[] = [];
+  const transport: RestCommitTransport = async (req) => {
+    requests.push(req);
+    const sha = /git\/trees\/([^/?]+)/.exec(req.url)?.[1];
+    if (sha === undefined || known[sha] === undefined) {
+      throw new Error(`GET ${req.url} failed: HTTP 404 Not Found`);
+    }
+    return {
+      status: 200,
+      json: {
+        sha,
+        truncated: false,
+        tree: [
+          { path: known[sha], type: "blob", mode: "100644", sha: "b1", size: 7 },
+        ],
+      },
+    };
+  };
+  return { transport, requests };
+}
+
+describe("getTree — canonical empty tree (@req:029c90ee-e10b-4398-909e-c2784fed7ac9)", () => {
+  it("A1: empty-tree SHA yields an empty entry list without any HTTP request", async () => {
+    const { transport, requests } = treeTransport({});
+
+    const entries = await getTree(
+      transport,
+      "test-owner",
+      "empty-repo",
+      EMPTY_TREE_SHA,
+    );
+
+    expect(entries).toEqual([]);
+    // No round trip: an empty tree contains zero blobs by definition, and the
+    // request GitHub would answer 404 is never issued.
+    expect(requests).toHaveLength(0);
+  });
+
+  it("A2 (control): a populated tree SHA is still fetched and parsed", async () => {
+    const { transport, requests } = treeTransport({ t1: "assets/a.md" });
+
+    const entries = await getTree(transport, "test-owner", "live-repo", "t1");
+
+    expect(entries).toEqual([
+      { path: "assets/a.md", blobSha: "b1", size: 7 },
+    ]);
+    expect(requests).toHaveLength(1);
+  });
+
+  it("A3 (negative control): an unknown tree SHA still propagates the 404", async () => {
+    const { transport, requests } = treeTransport({ t1: "assets/a.md" });
+
+    await expect(
+      getTree(transport, "test-owner", "dead-repo", "deadbeef"),
+    ).rejects.toThrow(/HTTP 404/);
+    // The short-circuit is keyed on the empty-tree SHA alone — it must not
+    // swallow genuine 404s, which is how "stopped the false alarm" stays
+    // distinguishable from "stopped detecting".
+    expect(requests).toHaveLength(1);
+  });
+
+  it("A4: the exported constant is the canonical git empty tree", () => {
+    expect(EMPTY_TREE_SHA).toBe("4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+  });
+});


### PR DESCRIPTION
Closes #4184
Req: `029c90ee-e10b-4398-909e-c2784fed7ac9` (approved)

## Problem

A branch head may legitimately reference the **canonical git empty tree**
`4b825dc642cb6eb9a060e54bf8d69288fbee4904`: the repo exists, the branch resolves,
nothing is committed yet. GitHub still answers **404** for `GET git/trees/<that sha>`
even when the repo is reachable and the PAT allowlists it — the 404 is a property of
the **request**, not of reachability.

`ParityValidator` read that 404 through `isNotFoundError` and reported `status: "error"`
with a warning naming **two false causes**: *"dead AssetSpace pointer, or the fine-grained
PAT does not allowlist this repo"*. The operator is sent to check a pointer and a token
scope that are both fine.

Worse: `ParityValidator.ts:860` gates discrepancy counting on `repo.status !== "checked"`,
so local files under an empty repo's mount **stayed invisible** — parity went quiet exactly
where it should have proposed a first push.

## Fix

`getTree` short-circuits `EMPTY_TREE_SHA` **before the transport call** — an empty tree
contains zero blobs by definition, so the answer is known without a round trip and without
inheriting GitHub's 404 for that SHA.

**Why here and not a new parity status.** The issue offered either shape — a dedicated
`empty` status or `checked` with `filesChecked: 0`. The latter is implemented because a new
status would satisfy the issue's *"⛔ молчать по факту пустоты нельзя"* constraint **in name
only**: any non-`checked` status skips discrepancy counting, so local files would stay
uncounted. Fixing the lowest layer also means all **14 `getTree` call-sites** (SyncEngine ×12,
ParityValidator, QuarantineResolver) inherit it, not parity alone.

## Revert-verify — both halves (per the issue)

Removing the short-circuit on a copy reddens **exactly**:

| axis | file | asserts |
|---|---|---|
| A1 | `githubRepoReader.empty-tree.test.ts` | empty-tree SHA → `[]`, **zero** HTTP requests |
| B1 | `ParityValidator.test.ts` | empty repo + one local asset → `checked`, `pending-local-add`, no PAT warning |
| B2 | `ParityValidator.test.ts` | empty repo, no local files → `checked`, clean, `ok` |

Controls that stay **green** under the same mutant (proving the axes are not vacuous, and
that detection did not stop):

- A2 — a populated tree SHA is still fetched and parsed
- A3 — an unknown tree SHA still propagates the 404 (the short-circuit is keyed on the empty-tree SHA alone)
- A4 — the exported constant is the canonical empty tree
- **pre-existing** `HTTP 404 → error with the fine-grained-PAT hint` — a genuinely unreachable repo still errors with the unchanged warning

That last control is the mandatory second half: without it, *"stopped the false alarm"* is
indistinguishable from *"stopped detecting"*.

## Gates run locally

| gate | result |
|---|---|
| `packages/core` full suite (CI form, perf excluded) | 381/383 suites, 8656 passed |
| the 2 non-green suites | `prototype-chain`, `QueryOptimization` — **green in isolation** (39/39); parallel-run contention, untouched by this diff |
| `check-cli-types` | `13/13` pairs — no new |
| `check-test-types` | `431/431` pairs — no new |
| `npm run check:types` | rc=0 |
| `validate-shard-assignments` / `check-test-antipatterns` / `check-coverage-monotonic` | rc=0 |
| eslint on changed files | 0 errors (9 pre-existing warnings, outside the diff) |

⛔ Elevated-risk path (`packages/core/src/services/sync/`) — **no `--auto` merge**;
`code-reviewer` + `advisor()` round-2 run before a manual squash merge.

https://claude.ai/code/session_01FjMAainJm4kAsiu1VxSAae