### PR TITLE
docs: two worktree/test gotchas that read as regressions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,18 @@ When fixing a bug, still run the directly-affected suite locally for a fast loop
 npm test -- packages/core/tests/integration/<affected-suite>.test.ts
 ```
 
+⛔ **Pass the path positionally — `--testPathPatterns` silently does NOT filter.** With that flag
+jest runs the **whole** set (~390 suites, ~90s) while the invocation still looks filtered, so
+failures from suites your diff never touched read as consequences of your change. Tell: the run
+takes minutes instead of seconds, and the output names suites you did not open. When invoking jest
+directly — e.g. from a worktree whose `node_modules` lives in the sibling checkout — keep the path
+as a bare argument:
+
+```bash
+node --experimental-vm-modules ../../exocortex/node_modules/jest/bin/jest.js \
+  --config packages/core/jest.config.js packages/core/tests/unit/<path>.test.ts
+```
+
 **Reference (historical, allowlist era):** PR #3189 — `create-instance-grounding.test.ts` was silently red on `main` (12/12 fail, missing parent.md fixture) because the allowlist never included it. That failure mode is now closed by the full-config gate; the lesson (coverage gates measure file/line %, not "did this suite pass") remains why the allowlist was dropped.
 
 ## TypeScript Tooling

--- a/DEV-TROUBLESHOOTING.md
+++ b/DEV-TROUBLESHOOTING.md
@@ -129,6 +129,25 @@ cd ~/Developer/exocortex-development
 
 **Remember**: Disk space is cheap, broken sessions are expensive.
 
+### Fresh worktree: suites fail with `ENOENT: scandir '.../packages/exoas-exocmd/exocmd'`
+
+`packages/exoas-exocmd` and `packages/exoas-exo` are **data submodules** (ontology assets),
+deliberately excluded from the npm workspaces. `git worktree add` does not initialise them, so
+suites that read vault fixtures fail on a missing directory. This is the **environment**, not your
+diff — and the failure count looks alarming enough to be mistaken for a regression you introduced.
+
+**Discriminator**: the message is `ENOENT` on a _submodule directory_, not a type or assertion
+error; and exactly the vault-fixture readers go red (`PrototypePreconditionForgetGuard`,
+`PrototypePreconditionRevertVerify`, `grounding-type-vault-fixture-parity`) while the rest of the
+suite set is green.
+
+```bash
+git submodule update --init packages/exoas-exocmd packages/exoas-exo
+```
+
+**Second discriminator, when the cause is still unclear**: run the same suite against the pristine
+file (`git stash -u`). Failing identically ⇒ environment.
+
 ---
 
 ## Git & CI Issues


### PR DESCRIPTION
Two gotchas that both cost a diagnostic cycle while shipping #4184 (PR #4215), and both for the same reason: the symptom looks like a defect in your own diff.

## `CLAUDE.md` §Test Suite Awareness

`--testPathPatterns` **silently does not filter** — jest runs the whole set (~390 suites, ~90s) while the invocation still looks filtered, so failures from suites the diff never touched read as consequences of the change.

The section already recommends the positional form via `npm test --`; what was missing is the flag's failure mode and the direct-jest invocation used from a worktree (whose `node_modules` lives in the sibling checkout).

## `DEV-TROUBLESHOOTING.md` §Worktree Issues

`packages/exoas-exocmd` / `packages/exoas-exo` are data submodules excluded from the npm workspaces, and `git worktree add` does not initialise them — so vault-fixture suites fail with `ENOENT: scandir`. Adds the discriminator (`ENOENT` on a *submodule directory* rather than a type/assertion error, and exactly the fixture readers go red) plus the one-line fix.

## Novelty checked, not assumed

Both lessons were grepped against the rules corpus before being written down (canary alive — 42 files match `revert-verify`):

- the single existing `testPathPatterns` mention is about CI dropping its allowlist — a different subject;
- the single existing `submodule update --init` mention is about detached HEAD on push — a different failure.

A third candidate ("a stale main checkout contaminates audit numbers") was **not** added: that class is already documented, and this was merely an instance of it.

## Scope

Docs only. 31 insertions, 0 deletions, no behaviour change. Both files are prettier-clean on `main`, so the pre-commit formatter is a no-op beyond the added lines (blast radius measured on copies: delta 0 for both).

https://claude.ai/code/session_01FjMAainJm4kAsiu1VxSAae
